### PR TITLE
Timeline Modal: Magnifying Feature

### DIFF
--- a/frontend/components/ArticleCarousel.js
+++ b/frontend/components/ArticleCarousel.js
@@ -24,7 +24,7 @@ const ArticleCarousel = ({articles, setArticle}) => {
                 articles.map((article, i) => (
                     <Carousel.Item key={i}>
                         <h3 className="text-center">{article.title}</h3>
-                        <p className="overflow-scroll article-height">{article.text}</p>
+                        <p className="overflow-scroll article-height p-2">{article.text}</p>
                     </Carousel.Item>
                 ))
             }

--- a/frontend/components/DocumentDisplay.js
+++ b/frontend/components/DocumentDisplay.js
@@ -31,7 +31,6 @@ const DocumentDisplay = ({document}) => {
 
         </>
     );
-
 };
 
 DocumentDisplay.propTypes = {

--- a/frontend/components/DocumentDisplay.js
+++ b/frontend/components/DocumentDisplay.js
@@ -1,18 +1,34 @@
-import React from "react";
+import React, {useState} from "react";
 import * as PropTypes from "prop-types";
 import "bootstrap/dist/css/bootstrap.min.css";
 import TEST_IMAGE from "../images/testing.jpg";
+import Magnifier from "react-magnifier";
+
 /**
  * Displays the Document and provides an option to zoom in
  * @param document document metadata (title, etc.)
  *
  */
 const DocumentDisplay = ({document}) => {
+    const [Scale, setScale] = useState(1.5);
+    const handleIncrement = () =>
+        setScale(currentCount => currentCount + 0.1);
+    const handleDecrement = () =>
+        setScale(currentCount => currentCount - 0.1);
 
-    // TODO: import magnifying feature and call it with document image from backend
+
+    // TODO: call magnifying feature with document image from backend
     return(
         <>
-            <img className="doc-image" src={document.image ? document.image : TEST_IMAGE} />
+            <Magnifier className="doc-image" src={document.image ? document.image : TEST_IMAGE}
+                mgShape='square' mgHeight={300} mgWidth={300}
+                mgMouseOffsetX={-50} mgMouseOffsetY={50} zoomFactor={Scale}/>
+            <h5>Magnification Scale: {Scale.toFixed(2)}</h5>
+            <button className="btn btn-outline-secondary mx-2" type="button"
+                onClick={handleIncrement}>Increase</button>
+            <button className="btn btn-outline-secondary" type="button"
+                onClick={handleDecrement}>Decrease </button>
+
         </>
     );
 

--- a/frontend/scss/document.scss
+++ b/frontend/scss/document.scss
@@ -31,5 +31,11 @@
 }
 
 .doc-image {
-    max-height: 100%;
+    height: 80% !important;
+}
+
+.doc-image img {
+    height: 100%;
+    width: auto;
+    border: 1px solid black;
 }


### PR DESCRIPTION
This PR merges a magnifying feature into the document modal, allowing users to hover over the document image and zoom in to see the document more clearly. Users also have the ability to adjust the magnifying ratio.

<img width="1440" alt="Screen Shot 2022-01-24 at 3 34 44 PM" src="https://user-images.githubusercontent.com/32581282/150860810-38f9ae68-48a7-4d2e-85c3-f237edc52654.png">
